### PR TITLE
Optional formula notation input for importMapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,8 +51,8 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     github::Minotau-R/MultiFactor
-URL: https://github.com/thomazbastiaanssen/ariadne
-BugReports: https://github.com/thomazbastiaanssen/ariadne/issues
+URL: https://github.com/Minotau-R/ariadne
+BugReports: https://github.com/Minotau-R/ariadne/issues
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr

--- a/R/importMapping.R
+++ b/R/importMapping.R
@@ -1,11 +1,11 @@
 #' Import mappings from a file or a database
-#' 
+#'
 #' @name importMapping
 #' @rdname importMapping
-#' 
+#'
 #' @description
 #' \code{importMapping} retrieves mapping information from a file or a database.
-#' 
+#'
 #' @param map.file \code{Character vector}. One or more paths to custom mapping
 #'   files or one or more names from the available databases
 #'   (\code{c("ChocoPhlAn", "Woltka")}).
@@ -16,15 +16,18 @@
 #' @param to \code{Character vector}. One or more strings specifying the
 #'   values to which mapping is performed. (Default: \code{NULL})
 #'
+#' @param formula \code{formula scalar}. Optional. Formula syntax specifying
+#'     `from` and `to`, e.g., `from ~ to`. (Default: \code{NULL})
+#'
 #' @param merge \code{Logical scalar}. Should multiple mapping files be merged.
 #'   (Default: \code{TRUE}).
-#' 
+#'
 #' @param verbose \code{Logical scalar}. Should information on execution be
 #'   printed in the console. (Default: \code{TRUE}).
-#' 
+#'
 #' @details
 #' Structure of \code{map.file}
-#' 
+#'
 #' Currently, the following databases are available:
 #' \itemize{
 #'   \item{\code{"ChocoPhlAn"}: x-to-uniref mapping files from bioBakery
@@ -40,7 +43,7 @@
 #'       \item{to: "uniref90"}
 #'     }}
 #' }
-#' 
+#'
 #' @return
 #' \code{importMapping} returns a named list of vectors, where each vector is a
 #' mapping key and its elements are the mapped values.
@@ -48,17 +51,17 @@
 #' @examples
 #' # Import eggnog-to-uniref90 mapping from ChocoPhlAn
 #' map1 <- importMapping("ChocoPhlAn", from = "eggnog", to = "uniref90")
-#' 
-#' # Import ko-to-uniref90 mapping from ChocoPhlAn
-#' map2 <- importMapping("ChocoPhlAn", from = "ko", to = "uniref90")
-#' 
+#'
+#' # Import ko-to-uniref90 mapping from ChocoPhlAn using formula notation
+#' map2 <- importMapping("ChocoPhlAn", formula = ko ~ uniref90)
+#'
 #' # Import and merge ko- and eggnog-to-uniref90 mappings from ChocoPhlAn
 #' map3 <- importMapping(
 #'     "ChocoPhlAn",
 #'     from = c("eggnog", "ko"),
 #'     to = "uniref90"
 #' )
-#' 
+#'
 #' # Import local mapping file
 #' # map4 <- importMapping("path/to/file")
 NULL
@@ -84,8 +87,15 @@ MappingDatabases <- list(
 
 
 S7::method(importMapping, S7::class_character) <- function(
-    map.file, from = NA, to = NA, merge = TRUE, verbose = TRUE){
-    
+    map.file, from = NA, to = NA, formula = NULL, merge = TRUE, verbose = TRUE){
+
+    if(!is.null(formula)){
+        stopifnot("'from' and 'to' arguments cannot be used with 'formula'. " =
+                      all(is.na(c(from, to))))
+
+        from <- all.vars(formula)[1]
+        to <- all.vars(formula)[2]
+    }
     # Find number of mapping files
     input.lengths <- lengths(list(map.file, from, to))
     max.length <- max(input.lengths)

--- a/R/importMapping.R
+++ b/R/importMapping.R
@@ -10,14 +10,14 @@
 #'   files or one or more names from the available databases
 #'   (\code{c("ChocoPhlAn", "Woltka")}).
 #'
+#' @param formula \code{formula scalar}. Formula specifying the source and
+#'   target of mapping in the syntax \code{from ~ to}. (Default: \code{NULL})
+#'
 #' @param from \code{Character vector}. One or more strings specifying the
 #'   keys from which mapping is performed. (Default: \code{NULL})
 #'
 #' @param to \code{Character vector}. One or more strings specifying the
 #'   values to which mapping is performed. (Default: \code{NULL})
-#'
-#' @param formula \code{formula scalar}. Optional. Formula syntax specifying
-#'     `from` and `to`, e.g., `from ~ to`. (Default: \code{NULL})
 #'
 #' @param merge \code{Logical scalar}. Should multiple mapping files be merged.
 #'   (Default: \code{TRUE}).
@@ -26,7 +26,8 @@
 #'   printed in the console. (Default: \code{TRUE}).
 #'
 #' @details
-#' Structure of \code{map.file}
+#' Either \code{formula} or both \code{from} and \code{to} should be specified.
+#' In the latter, also vector inputs are allowed.
 #'
 #' Currently, the following databases are available:
 #' \itemize{
@@ -50,10 +51,10 @@
 #'
 #' @examples
 #' # Import eggnog-to-uniref90 mapping from ChocoPhlAn
-#' map1 <- importMapping("ChocoPhlAn", from = "eggnog", to = "uniref90")
+#' map1 <- importMapping("ChocoPhlAn", eggnog ~ uniref90)
 #'
-#' # Import ko-to-uniref90 mapping from ChocoPhlAn using formula notation
-#' map2 <- importMapping("ChocoPhlAn", formula = ko ~ uniref90)
+#' # Import ko-to-uniref90 mapping from ChocoPhlAn
+#' map2 <- importMapping("ChocoPhlAn", ko ~ uniref90)
 #'
 #' # Import and merge ko- and eggnog-to-uniref90 mappings from ChocoPhlAn
 #' map3 <- importMapping(
@@ -87,12 +88,14 @@ MappingDatabases <- list(
 
 
 S7::method(importMapping, S7::class_character) <- function(
-    map.file, from = NA, to = NA, formula = NULL, merge = TRUE, verbose = TRUE){
-
-    if(!is.null(formula)){
+    map.file, formula = NULL, from = NA, to = NA, merge = TRUE, verbose = TRUE){
+    
+    # If formula is defined
+    if( !is.null(formula) ){
+        # Check that from and to are empty
         stopifnot("'from' and 'to' arguments cannot be used with 'formula'. " =
-                      all(is.na(c(from, to))))
-
+            all(is.na(c(from, to))))
+        # Replace from and to with formula elements
         from <- all.vars(formula)[1]
         to <- all.vars(formula)[2]
     }

--- a/R/mapModules.R
+++ b/R/mapModules.R
@@ -41,7 +41,7 @@
 #' gbm <- importModules("GBM")
 #' 
 #' # Import ko-to-uniref90 mapping
-#' map <- importMapping("ChocoPhlAn", from = "ko", to = "uniref90")
+#' map <- importMapping("ChocoPhlAn", ko ~ uniref90)
 #' 
 #' # Map modules to UniRef90
 #' modules <- mapModules(

--- a/R/mapModules.R
+++ b/R/mapModules.R
@@ -124,7 +124,6 @@ S7::method(mapModules, S7::class_list) <- function(
     z <- bplapply(x, function(values)
         unlist(y[names(y) %in% values], use.names = FALSE))
     return(z)
-    print("hello")
 }
 
 #' @importFrom MultiFactor as.LinkMap

--- a/man/importMapping.Rd
+++ b/man/importMapping.Rd
@@ -17,6 +17,9 @@ keys from which mapping is performed. (Default: \code{NULL})}
 \item{to}{\code{Character vector}. One or more strings specifying the
 values to which mapping is performed. (Default: \code{NULL})}
 
+\item{formula}{\code{formula scalar}. Optional. Formula syntax specifying
+\code{from} and \code{to}, e.g., \code{from ~ to}. (Default: \code{NULL})}
+
 \item{merge}{\code{Logical scalar}. Should multiple mapping files be merged.
 (Default: \code{TRUE}).}
 
@@ -53,8 +56,8 @@ Currently, the following databases are available:
 # Import eggnog-to-uniref90 mapping from ChocoPhlAn
 map1 <- importMapping("ChocoPhlAn", from = "eggnog", to = "uniref90")
 
-# Import ko-to-uniref90 mapping from ChocoPhlAn
-map2 <- importMapping("ChocoPhlAn", from = "ko", to = "uniref90")
+# Import ko-to-uniref90 mapping from ChocoPhlAn using formula notation
+map2 <- importMapping("ChocoPhlAn", formula = ko ~ uniref90)
 
 # Import and merge ko- and eggnog-to-uniref90 mappings from ChocoPhlAn
 map3 <- importMapping(

--- a/man/importMapping.Rd
+++ b/man/importMapping.Rd
@@ -11,14 +11,14 @@ importMapping(map.file, ...)
 files or one or more names from the available databases
 (\code{c("ChocoPhlAn", "Woltka")}).}
 
+\item{formula}{\code{formula scalar}. Formula specifying the source and
+target of mapping in the syntax \code{from ~ to}. (Default: \code{NULL})}
+
 \item{from}{\code{Character vector}. One or more strings specifying the
 keys from which mapping is performed. (Default: \code{NULL})}
 
 \item{to}{\code{Character vector}. One or more strings specifying the
 values to which mapping is performed. (Default: \code{NULL})}
-
-\item{formula}{\code{formula scalar}. Optional. Formula syntax specifying
-\code{from} and \code{to}, e.g., \code{from ~ to}. (Default: \code{NULL})}
 
 \item{merge}{\code{Logical scalar}. Should multiple mapping files be merged.
 (Default: \code{TRUE}).}
@@ -34,7 +34,8 @@ mapping key and its elements are the mapped values.
 \code{importMapping} retrieves mapping information from a file or a database.
 }
 \details{
-Structure of \code{map.file}
+Either \code{formula} or both \code{from} and \code{to} should be specified.
+In the latter, also vector inputs are allowed.
 
 Currently, the following databases are available:
 \itemize{
@@ -54,10 +55,10 @@ Currently, the following databases are available:
 }
 \examples{
 # Import eggnog-to-uniref90 mapping from ChocoPhlAn
-map1 <- importMapping("ChocoPhlAn", from = "eggnog", to = "uniref90")
+map1 <- importMapping("ChocoPhlAn", eggnog ~ uniref90)
 
-# Import ko-to-uniref90 mapping from ChocoPhlAn using formula notation
-map2 <- importMapping("ChocoPhlAn", formula = ko ~ uniref90)
+# Import ko-to-uniref90 mapping from ChocoPhlAn
+map2 <- importMapping("ChocoPhlAn", ko ~ uniref90)
 
 # Import and merge ko- and eggnog-to-uniref90 mappings from ChocoPhlAn
 map3 <- importMapping(

--- a/man/mapModules.Rd
+++ b/man/mapModules.Rd
@@ -46,7 +46,7 @@ and/or relationships, depending on whether \code{mode} is \code{"single"} or
 gbm <- importModules("GBM")
 
 # Import ko-to-uniref90 mapping
-map <- importMapping("ChocoPhlAn", from = "ko", to = "uniref90")
+map <- importMapping("ChocoPhlAn", ko ~ uniref90)
 
 # Map modules to UniRef90
 modules <- mapModules(

--- a/tests/testthat/test-importMapping.R
+++ b/tests/testthat/test-importMapping.R
@@ -10,9 +10,12 @@ test_that("importMapping", {
         "'to' should be defined and be one of uniref50, uniref90."
     )
     
-    expect_no_error(
-        map <- importMapping("ChocoPhlAn", from = "ko", to = "uniref90")
+    expect_error(
+        importMapping("ChocoPhlAn", from = "ko", formula = ko ~ uniref90),
+        "'from' and 'to' arguments cannot be used with 'formula'."
     )
+    
+    map <- importMapping("ChocoPhlAn", from = "ko", to = "uniref90")
     
     expect_named(map)
   

--- a/tests/testthat/test-mapModules.R
+++ b/tests/testthat/test-mapModules.R
@@ -1,7 +1,7 @@
 test_that("mapModules", {
     
     gbm <- importModules("GBM")
-    eggnog.uniref90 <- importMapping("ChocoPhlAn", "eggnog", "uniref90")
+    eggnog.uniref90 <- importMapping("ChocoPhlAn", eggnog ~ uniref90)
     
     expect_error(
         mapModules(eggnog.uniref90, gbm),

--- a/vignettes/ariadne.Rmd
+++ b/vignettes/ariadne.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "# ariadne: module integration by on-demand translation of annotations using R"
+title: "# ariadne: on-demand annotation and module analysis"
 author: 
   - name: Giulio Benedetti
     affiliation: University of Turku
@@ -32,7 +32,7 @@ knitr::opts_chunk$set(
 
 # Introduction
 
-ariadne provides a rapid and robust approach to incorporate taxonomic
+ariadne aims to provide a rapid and robust approach to incorporate taxonomic
 and functional module analyses into your bioinformatic workflow. Despite the
 presence of specialised bioinformatic tools, on-demand functional annotation of
 taxonomic features directly in R has remained challenging. To make this simple,
@@ -59,7 +59,6 @@ Here, the terms "module" and "signature" are used in place of each other.
 ```{r}
 library(ariadne)
 library(mia)
-library(miaViz)
 
 # Import dataset
 data("Tengeler2020", package = "mia")
@@ -75,12 +74,12 @@ library(bugsigdbr)
 bsdb <- importBugSigDB()
 
 # Retrieve microbial signatures
-bsdb.mods <- getSignatures(bsdb, tax.id.type = "metaphlan")
+bsdb.sigs <- getSignatures(bsdb, tax.id.type = "metaphlan")
 ```
 
 ```{r}
 # Add module membership to rowData
-tse <- addModules(tse, bsdb.mods)
+tse <- addModules(tse, bsdb.sigs)
 ```
 
 ## Retrieve functional modules
@@ -90,140 +89,49 @@ tse <- addModules(tse, bsdb.mods)
 gbm <- importModules("GBM")
 
 # Import ko-to-uniref90 mapping
-ko.uniref90 <- importMapping(
-    "ChocoPhlAn",
-    from = c("eggnog", "ko"),
-    to = "uniref90"
-)
+ko.uniref90 <- importMapping("ChocoPhlAn", ko ~ uniref90)
 ```
 
 ```{r}
 # Map modules to taxa
-gbm.mods <- mapModules(
-    gbm,
-    ko.uniref90,
-    mode = "andor",
-    uniprot = TRUE,
-    remove.empty = TRUE
-)
+gbm.sigs <- mapModules(gbm, ko.uniref90)
 ```
 
 ```{r}
 # Add module membership to rowData
-tse <- addModules(
-    tse,
-    gbm.mods,
-    by = 1L,
-    group = "taxonomy"
-)
+tse <- addModules(tse, gbm.sigs)
 ```
 
 ## Module analysis
 
 ```{r}
 # Collect all module names
-all.mods <- c(names(bsdb.mods), names(gbm.mods))
+all.sigs <- c(names(bsdb.sigs), names(gbm.sigs))
 
 # Agglomerate features by every module
-altExp(tse, "modules") <- agglomerateByModule(tse, by = 1L, group = names(gbm.mods))
-
-# Find top 5 modules by average count
-top.mods <- getTop(
-    altExp(tse, "modules"),
-    assay.type = "counts"
-)
+tse.mod <- agglomerateByModule(tse, by = 1L, group = all.sigs)
 ```
 
 ```{r include=FALSE}
 # Add arg to agglomerateByModule to remove.empty
-# keep <- rowSums(assay(tse.mod)) > 0
-# tse.mod <- tse.mod[keep, ]
+keep <- rowSums(assay(tse.mod)) > 0
+tse.mod <- tse.mod[keep, ]
 ```
 
 Make some plots
 
 ```{r}
-tse <- swapAltExp(
-    tse,
-    name = "modules",
-    saved = "features",
-    withColData = FALSE
-)
+
 ```
 
-
-```{r}
-plotAbundance(
-    tse[top.mods, ],
-    assay.type = "counts",
-    as.relative = TRUE,
-    col.var = "patient_status",
-    order.col.by = "patient_status",
-    add.legend = FALSE
-)
-```
-
-
-```{r}
-plotAbundanceDensity(
-    tse,
-    layout = "density",
-    n = 5,
-    assay.type = "counts",
-    colour.by = "patient_status"
-)
-```
-
-```{r}
-library(ggplot2)
-
-mse <- meltSE(tse, assay.type = "counts", add.col = TRUE)
-
-ggplot(mse, aes(x = SampleID, y = FeatureID, fill = counts)) +
-    geom_tile() +
-    #facet_wrap(. ~ patient_status) +
-    scale_fill_gradient2(low = "white", high = "red") +
-    labs(x = "Samples") +
-    theme(axis.text = element_blank(),
-          axis.title.y = element_blank(),
-          axis.ticks.x = element_blank())
-```
-
-```{r}
-# Heatmap(assay(tse))
-```
 
 ## Microbe-set enrichment analysis
-
-```{r}
-tse <- transformAssay(tse, method = "relabundance")
-```
-
-
-```{r}
-# library(rstatix)
-
-# df <- meltSE(tse, assay.type = "counts", add.col = TRUE)
-
-# df |>
-#   group_by(FeatureID) |>
-#   t_test(counts ~ patient_status) |>
-#   filter(!is.na(p)) |>
-#   adjust_pvalue(method = "fdr") |>
-#   filter(p < 0.05) |>
-#   select(FeatureID, p, p.adj)
-```
-
-```{r}
-# my.list
-```
-
 
 # Resources
 
 ## Citation
 
-We hope that ariadne will be useful for your research. Please use the following
+We hope that miaDash will be useful for your research. Please use the following
 information to cite the package and the overall approach. Thank you!
 
 ```{r citation}

--- a/vignettes/ariadne.Rmd
+++ b/vignettes/ariadne.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "# ariadne: on-demand annotation and module analysis"
+title: "# ariadne: module integration by on-demand translation of annotations using R"
 author: 
   - name: Giulio Benedetti
     affiliation: University of Turku
@@ -32,7 +32,7 @@ knitr::opts_chunk$set(
 
 # Introduction
 
-ariadne aims to provide a rapid and robust approach to incorporate taxonomic
+ariadne provides a rapid and robust approach to incorporate taxonomic
 and functional module analyses into your bioinformatic workflow. Despite the
 presence of specialised bioinformatic tools, on-demand functional annotation of
 taxonomic features directly in R has remained challenging. To make this simple,
@@ -59,6 +59,7 @@ Here, the terms "module" and "signature" are used in place of each other.
 ```{r}
 library(ariadne)
 library(mia)
+library(miaViz)
 
 # Import dataset
 data("Tengeler2020", package = "mia")
@@ -74,12 +75,12 @@ library(bugsigdbr)
 bsdb <- importBugSigDB()
 
 # Retrieve microbial signatures
-bsdb.sigs <- getSignatures(bsdb, tax.id.type = "metaphlan")
+bsdb.mods <- getSignatures(bsdb, tax.id.type = "metaphlan")
 ```
 
 ```{r}
 # Add module membership to rowData
-tse <- addModules(tse, bsdb.sigs)
+tse <- addModules(tse, bsdb.mods)
 ```
 
 ## Retrieve functional modules
@@ -89,49 +90,140 @@ tse <- addModules(tse, bsdb.sigs)
 gbm <- importModules("GBM")
 
 # Import ko-to-uniref90 mapping
-ko.uniref90 <- importMapping("ChocoPhlAn", ko ~ uniref90)
+ko.uniref90 <- importMapping(
+    "ChocoPhlAn",
+    from = c("eggnog", "ko"),
+    to = "uniref90"
+)
 ```
 
 ```{r}
 # Map modules to taxa
-gbm.sigs <- mapModules(gbm, ko.uniref90)
+gbm.mods <- mapModules(
+    gbm,
+    ko.uniref90,
+    mode = "andor",
+    uniprot = TRUE,
+    remove.empty = TRUE
+)
 ```
 
 ```{r}
 # Add module membership to rowData
-tse <- addModules(tse, gbm.sigs)
+tse <- addModules(
+    tse,
+    gbm.mods,
+    by = 1L,
+    group = "taxonomy"
+)
 ```
 
 ## Module analysis
 
 ```{r}
 # Collect all module names
-all.sigs <- c(names(bsdb.sigs), names(gbm.sigs))
+all.mods <- c(names(bsdb.mods), names(gbm.mods))
 
 # Agglomerate features by every module
-tse.mod <- agglomerateByModule(tse, by = 1L, group = all.sigs)
+altExp(tse, "modules") <- agglomerateByModule(tse, by = 1L, group = names(gbm.mods))
+
+# Find top 5 modules by average count
+top.mods <- getTop(
+    altExp(tse, "modules"),
+    assay.type = "counts"
+)
 ```
 
 ```{r include=FALSE}
 # Add arg to agglomerateByModule to remove.empty
-keep <- rowSums(assay(tse.mod)) > 0
-tse.mod <- tse.mod[keep, ]
+# keep <- rowSums(assay(tse.mod)) > 0
+# tse.mod <- tse.mod[keep, ]
 ```
 
 Make some plots
 
 ```{r}
-
+tse <- swapAltExp(
+    tse,
+    name = "modules",
+    saved = "features",
+    withColData = FALSE
+)
 ```
 
 
+```{r}
+plotAbundance(
+    tse[top.mods, ],
+    assay.type = "counts",
+    as.relative = TRUE,
+    col.var = "patient_status",
+    order.col.by = "patient_status",
+    add.legend = FALSE
+)
+```
+
+
+```{r}
+plotAbundanceDensity(
+    tse,
+    layout = "density",
+    n = 5,
+    assay.type = "counts",
+    colour.by = "patient_status"
+)
+```
+
+```{r}
+library(ggplot2)
+
+mse <- meltSE(tse, assay.type = "counts", add.col = TRUE)
+
+ggplot(mse, aes(x = SampleID, y = FeatureID, fill = counts)) +
+    geom_tile() +
+    #facet_wrap(. ~ patient_status) +
+    scale_fill_gradient2(low = "white", high = "red") +
+    labs(x = "Samples") +
+    theme(axis.text = element_blank(),
+          axis.title.y = element_blank(),
+          axis.ticks.x = element_blank())
+```
+
+```{r}
+# Heatmap(assay(tse))
+```
+
 ## Microbe-set enrichment analysis
+
+```{r}
+tse <- transformAssay(tse, method = "relabundance")
+```
+
+
+```{r}
+# library(rstatix)
+
+# df <- meltSE(tse, assay.type = "counts", add.col = TRUE)
+
+# df |>
+#   group_by(FeatureID) |>
+#   t_test(counts ~ patient_status) |>
+#   filter(!is.na(p)) |>
+#   adjust_pvalue(method = "fdr") |>
+#   filter(p < 0.05) |>
+#   select(FeatureID, p, p.adj)
+```
+
+```{r}
+# my.list
+```
+
 
 # Resources
 
 ## Citation
 
-We hope that miaDash will be useful for your research. Please use the following
+We hope that ariadne will be useful for your research. Please use the following
 information to cite the package and the overall approach. Thank you!
 
 ```{r citation}

--- a/vignettes/comparison.Rmd
+++ b/vignettes/comparison.Rmd
@@ -63,11 +63,7 @@ gmm <- importModules("GMM")
 ```
 
 ```{r}
-ko.uniref90 <- importMapping(
-    "ChocoPhlAn",
-    from = "ko",
-    to = "uniref90"
-)
+ko.uniref90 <- importMapping("ChocoPhlAn", ko ~ uniref90)
 ```
 
 
@@ -158,7 +154,7 @@ gmm <- importModules("GMM")
 ```
 
 ```{r}
-ko.uniref90 <- importMapping("ChocoPhlAn", "ko", "uniref90")
+ko.uniref90 <- importMapping("ChocoPhlAn", ko ~ uniref90)
 ```
 
 ```{r}


### PR DESCRIPTION
Hi! 
Here's an optional alternate input option for `importMapping`. 
Currently, it only works for simple input, but  I'd like the user to just state 'to' and 'from', without *having* to care about which specific intermediate steps should be taken. 

So for instance: 
if we have some database with mapping files `a2b`, `b2c`, `c2d`: 

 `importMapping( "some_database", formula = a ~ d )` 
would be equivalent to 
 `importMapping( "some_database", to = c("a", "b", "c"), from = c("b", "c", "d") ) ` 